### PR TITLE
Add Gemini provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | OpenAI | GPT-4 | Advanced language model for text generation. | 2048 tokens | Diverse internet text | `temperature`: (Optional[float]) Controls the randomness of the output.  `max_tokens`: (Optional[int]) Limits the length of the generated text. |
 | Anthropic | Claude | Generative model with enhancements in safety and ethics. | 4096 tokens | Broad and ethically sourced datasets | `temperature`: (Optional[float]) Controls the randomness of the output.  `max_tokens`: (Optional[int]) Limits the length of the generated text. |
 | Bedrock | Llama3 |  |  |  | `temperature`: (Optional[float]) Controls the randomness of the output.  `max_tokens`: (Optional[int]) Limits the length of the generated text. |
+| Gemini | Gemini 2 (Flash/Pro) | Google's generative models. | - | Proprietary | `temperature`: (Optional[float])  `max_tokens`: (Optional[int]) |
 
 ## Parameters
 
@@ -48,6 +49,8 @@ Create a .env file in the root directory and set the following variables:
 ```bash
 OPENAI_KEY=your_openai_api_key
 ANTHROPIC_KEY=your_anthropic_api_key
+# Gemini models
+GEMINI_KEY=your_gemini_api_key
 # Bedrock credentials are configured in .env.bedrock
 ```
 
@@ -55,6 +58,20 @@ ANTHROPIC_KEY=your_anthropic_api_key
 Run the application:
 ```bash
 python src/app.py
+```
+
+### Example request using Gemini
+
+```bash
+curl -X POST http://localhost:8080/v1/generate/text \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": {"name": "gemini", "model": {"name": "gemini-2.0-pro"}},
+    "prompt": {"parameter": {"temperature": 0.7, "max_tokens": 150},
+               "messages": [{"role": "user", "content": "Qual a capital da França?"}]},
+    "tool_choice": "auto",
+    "store": true
+  }'
 ```
 
 **Project Structure:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ httpx==0.27.0
 anthropic
 openai==1.13.3
 boto3
+google-generativeai>=0.6

--- a/src/hub/api/adapter/service/provider_service.py
+++ b/src/hub/api/adapter/service/provider_service.py
@@ -3,6 +3,7 @@ from hub.api.adapter.http.v1.model.request.text_request import TextRequest
 from provider.openai.adapter.openai_adapter import OpenAIAdapter
 from provider.antrhopic.adapter.anthropic_adapter import AnthropicAdapter
 from provider.bedrock.adapter.bedrock_adapter import BedrockAdapter
+from provider.gemini.adapter.gemini_adapter import GeminiAdapter
 from provider.port.interface_port import InterfacePort
 
 
@@ -10,6 +11,7 @@ class ProviderService:
     def __init__(self):
         self.providers = {
             "openai": OpenAIAdapter(),
+            "gemini": GeminiAdapter(),
         }
 
     def generate_text(

--- a/src/provider/gemini/adapter/gemini_adapter.py
+++ b/src/provider/gemini/adapter/gemini_adapter.py
@@ -1,0 +1,22 @@
+from hub.api.adapter.http.v1.model.request.text_request import TextRequest
+from hub.api.adapter.http.v1.model.response.text_response import TextResponse
+
+from provider.port.interface_port import InterfacePort
+from provider.gemini.service.gemini_service import GeminiService
+from provider.gemini.model import mapper
+
+
+class GeminiAdapter(InterfacePort):
+    def __init__(self):
+        self.gemini = GeminiService()
+
+    def generate_text(self, text_request_body: TextRequest) -> TextResponse:
+        messages, generation_config, tools = mapper.serialize_request(text_request_body)
+        response = self.gemini.generate(
+            model=text_request_body.provider.model.name,
+            messages=messages,
+            generation_config=generation_config,
+            tools=tools,
+            tool_choice=text_request_body.tool_choice or "auto",
+        )
+        return mapper.deserialize_response(response)

--- a/src/provider/gemini/model/mapper.py
+++ b/src/provider/gemini/model/mapper.py
@@ -1,0 +1,88 @@
+import json
+import google.generativeai as genai
+from hub.api.adapter.http.v1.model.request.text_request import TextRequest
+from hub.api.adapter.http.v1.model.response.text_response import (
+    TextResponse,
+    Usage,
+    Prompt,
+    Message as MessageResponse,
+    Tool as ToolResponse,
+)
+
+
+def serialize_request(text_request: TextRequest):
+    messages = [
+        {"role": msg.role, "parts": [{"text": msg.content}]}
+        for msg in text_request.prompt.messages
+    ]
+
+    generation_config = {}
+    if text_request.prompt.parameter is not None:
+        if text_request.prompt.parameter.temperature is not None:
+            generation_config["temperature"] = text_request.prompt.parameter.temperature
+        if text_request.prompt.parameter.maxTokens is not None:
+            generation_config["max_output_tokens"] = text_request.prompt.parameter.maxTokens
+    generation_config = generation_config or None
+
+    tools = None
+    if text_request.tools:
+        tool_list = []
+        for tool in text_request.tools:
+            params = None
+            if tool.parameters is not None:
+                params = {
+                    "type": tool.parameters.type,
+                    "properties": {
+                        k: {
+                            "type": v.type,
+                            "description": v.description,
+                            "enum": v.enum,
+                        }
+                        for k, v in tool.parameters.properties.items()
+                    },
+                    "required": tool.parameters.required or [],
+                }
+            func_decl = genai.types.content_types.FunctionDeclaration(
+                name=tool.name,
+                description=tool.description,
+                parameters=params,
+            )
+            tool_list.append(
+                genai.types.content_types.Tool(function_declarations=[func_decl])
+            )
+        tools = tool_list
+
+    return messages, generation_config, tools
+
+
+def deserialize_response(response) -> TextResponse:
+    usage = None
+    if getattr(response, "usage_metadata", None):
+        usage = Usage(
+            completionTokens=response.usage_metadata.candidate_token_count,
+            promptTokens=response.usage_metadata.prompt_token_count,
+            totalTokens=response.usage_metadata.total_token_count,
+        )
+
+    messages = [
+        MessageResponse(role="assistant", content=response.text)
+    ]
+
+    tools = []
+    if response.candidates:
+        candidate = response.candidates[0]
+        for part in getattr(candidate.content, "parts", []):
+            fc = getattr(part, "function_call", None)
+            if fc is not None:
+                try:
+                    arguments = json.loads(fc.args)
+                except Exception:
+                    arguments = {}
+                tools.append(
+                    ToolResponse(name=fc.name, arguments=arguments)
+                )
+    return TextResponse(
+        usage=usage,
+        prompt=Prompt(messages=messages),
+        tools=tools or None,
+    )

--- a/src/provider/gemini/service/gemini_service.py
+++ b/src/provider/gemini/service/gemini_service.py
@@ -1,0 +1,34 @@
+import os
+from dotenv import load_dotenv
+import google.generativeai as genai
+from google.generativeai.types import generation_types
+from google.generativeai.types import content_types
+
+
+class GeminiService:
+    def __init__(self) -> None:
+        load_dotenv()
+        genai.configure(api_key=os.getenv("GEMINI_KEY"))
+
+    def generate(
+        self,
+        model: str,
+        messages: list,
+        generation_config: dict | None = None,
+        tools: list | None = None,
+        tool_choice: str | None = None,
+    ) -> generation_types.GenerateContentResponse:
+        tool_config = None
+        if tools is not None and tool_choice is not None:
+            tool_config = {
+                "function_calling_config": {
+                    "mode": tool_choice.upper()
+                }
+            }
+        gen_model = genai.GenerativeModel(model)
+        return gen_model.generate_content(
+            messages,
+            generation_config=generation_config,
+            tools=tools,
+            tool_config=tool_config,
+        )

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -1,0 +1,46 @@
+import types
+import sys
+import os
+sys.path.insert(0, os.path.abspath('src'))
+import google.generativeai as genai
+from provider.gemini.adapter.gemini_adapter import GeminiAdapter
+from hub.api.adapter.http.v1.model.request.text_request import (
+    TextRequest, Provider, ProviderModel, Prompt, PromptParameter, Message
+)
+
+
+class DummyModel:
+    def generate_content(self, messages, generation_config=None, tools=None, tool_config=None):
+        class Usage:
+            prompt_token_count = 75
+            candidate_token_count = 8
+            total_token_count = 83
+        class FunctionCall:
+            name = "get_weather"
+            args = '{"city": "Paris"}'
+        class Part:
+            function_call = FunctionCall()
+        class Candidate:
+            content = types.SimpleNamespace(parts=[Part()])
+        return types.SimpleNamespace(
+            text="A capital da França é Paris.",
+            candidates=[Candidate()],
+            usage_metadata=Usage(),
+        )
+
+def test_generate_text(monkeypatch):
+    monkeypatch.setattr(genai, 'GenerativeModel', lambda name: DummyModel())
+    adapter = GeminiAdapter()
+    request = TextRequest(
+        provider=Provider(name="gemini", model=ProviderModel(name="gemini-2.0-pro")),
+        prompt=Prompt(
+            parameter=PromptParameter(temperature=0.7, max_tokens=150),
+            messages=[Message(role="user", content="Qual a capital da França?")]
+        ),
+        tool_choice="auto",
+    )
+    resp = adapter.generate_text(request)
+    assert resp.prompt.messages[0].content == "A capital da França é Paris."
+    assert resp.usage.totalTokens == 83
+    assert resp.tools[0].name == "get_weather"
+    assert resp.tools[0].arguments == {"city": "Paris"}


### PR DESCRIPTION
## Summary
- add Gemini adapter, service, and mapper
- register provider in service
- add google-generativeai dependency
- document Gemini usage in README
- include basic integration test using a mocked Gemini model

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436f3e5ce8832892a4213facb2c4cb