### PR TITLE
Update Gemini provider to google-genai

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ python src/app.py
 ```
 
 ### Example request using Gemini
+The Gemini provider relies on the official `google-genai` SDK.
 
 ```bash
 curl -X POST http://localhost:8080/v1/generate/text \

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ httpx==0.27.0
 anthropic
 openai==1.13.3
 boto3
-google-generativeai>=0.6
+google-genai>=1.19.0

--- a/src/provider/gemini/model/mapper.py
+++ b/src/provider/gemini/model/mapper.py
@@ -1,5 +1,4 @@
-import json
-import google.generativeai as genai
+import google.genai as genai
 from hub.api.adapter.http.v1.model.request.text_request import TextRequest
 from hub.api.adapter.http.v1.model.response.text_response import (
     TextResponse,
@@ -42,13 +41,13 @@ def serialize_request(text_request: TextRequest):
                     },
                     "required": tool.parameters.required or [],
                 }
-            func_decl = genai.types.content_types.FunctionDeclaration(
+            func_decl = genai.types.FunctionDeclaration(
                 name=tool.name,
                 description=tool.description,
                 parameters=params,
             )
             tool_list.append(
-                genai.types.content_types.Tool(function_declarations=[func_decl])
+                genai.types.Tool(function_declarations=[func_decl])
             )
         tools = tool_list
 
@@ -59,7 +58,7 @@ def deserialize_response(response) -> TextResponse:
     usage = None
     if getattr(response, "usage_metadata", None):
         usage = Usage(
-            completionTokens=response.usage_metadata.candidate_token_count,
+            completionTokens=response.usage_metadata.candidates_token_count,
             promptTokens=response.usage_metadata.prompt_token_count,
             totalTokens=response.usage_metadata.total_token_count,
         )
@@ -74,10 +73,7 @@ def deserialize_response(response) -> TextResponse:
         for part in getattr(candidate.content, "parts", []):
             fc = getattr(part, "function_call", None)
             if fc is not None:
-                try:
-                    arguments = json.loads(fc.args)
-                except Exception:
-                    arguments = {}
+                arguments = fc.args or {}
                 tools.append(
                     ToolResponse(name=fc.name, arguments=arguments)
                 )

--- a/src/provider/gemini/service/gemini_service.py
+++ b/src/provider/gemini/service/gemini_service.py
@@ -1,14 +1,13 @@
 import os
 from dotenv import load_dotenv
-import google.generativeai as genai
-from google.generativeai.types import generation_types
-from google.generativeai.types import content_types
+import google.genai as genai
+from google.genai.types import GenerateContentResponse
 
 
 class GeminiService:
     def __init__(self) -> None:
         load_dotenv()
-        genai.configure(api_key=os.getenv("GEMINI_KEY"))
+        self.client = genai.Client(api_key=os.getenv("GEMINI_KEY"))
 
     def generate(
         self,
@@ -17,18 +16,21 @@ class GeminiService:
         generation_config: dict | None = None,
         tools: list | None = None,
         tool_choice: str | None = None,
-    ) -> generation_types.GenerateContentResponse:
-        tool_config = None
-        if tools is not None and tool_choice is not None:
-            tool_config = {
-                "function_calling_config": {
-                    "mode": tool_choice.upper()
+    ) -> GenerateContentResponse:
+        config = {}
+        if generation_config:
+            config.update(generation_config)
+        if tools is not None:
+            config["tools"] = tools
+            if tool_choice is not None:
+                config["tool_config"] = {
+                    "function_calling_config": {
+                        "mode": tool_choice.upper()
+                    }
                 }
-            }
-        gen_model = genai.GenerativeModel(model)
-        return gen_model.generate_content(
-            messages,
-            generation_config=generation_config,
-            tools=tools,
-            tool_config=tool_config,
+
+        return self.client.models.generate_content(
+            model=model,
+            contents=messages,
+            config=config or None,
         )

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -2,34 +2,44 @@ import types
 import sys
 import os
 sys.path.insert(0, os.path.abspath('src'))
-import google.generativeai as genai
+import google.genai as genai
 from provider.gemini.adapter.gemini_adapter import GeminiAdapter
 from hub.api.adapter.http.v1.model.request.text_request import (
     TextRequest, Provider, ProviderModel, Prompt, PromptParameter, Message
 )
 
 
-class DummyModel:
-    def generate_content(self, messages, generation_config=None, tools=None, tool_config=None):
+class DummyModels:
+    def generate_content(self, model, contents, config=None):
         class Usage:
             prompt_token_count = 75
-            candidate_token_count = 8
+            candidates_token_count = 8
             total_token_count = 83
+
         class FunctionCall:
             name = "get_weather"
-            args = '{"city": "Paris"}'
+            args = {"city": "Paris"}
+
         class Part:
             function_call = FunctionCall()
+
         class Candidate:
             content = types.SimpleNamespace(parts=[Part()])
+
         return types.SimpleNamespace(
             text="A capital da França é Paris.",
             candidates=[Candidate()],
             usage_metadata=Usage(),
         )
 
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.models = DummyModels()
+
 def test_generate_text(monkeypatch):
-    monkeypatch.setattr(genai, 'GenerativeModel', lambda name: DummyModel())
+    monkeypatch.setenv("GEMINI_KEY", "dummy")
+    monkeypatch.setattr(genai, 'Client', lambda *a, **k: DummyClient())
     adapter = GeminiAdapter()
     request = TextRequest(
         provider=Provider(name="gemini", model=ProviderModel(name="gemini-2.0-pro")),


### PR DESCRIPTION
## Summary
- migrate Gemini service to use the `google-genai` SDK
- update request/response mapping for new SDK
- update tests and requirements
- document new library usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445bdd6f188328b0af906845948d31